### PR TITLE
[hotfix] Add git-revision-date plugin in requirements-doc

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,2 +1,3 @@
 mkdocs
 mkdocs-material
+mkdocs-git-revision-date-localized


### PR DESCRIPTION
This PR is to update the requirements-doc for adding the mkdocs plugin git-revision-date 