### PR TITLE
(PR52) chore: align dependency pinning policy across all repo

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-ruff==0.9.10
-mypy==1.15.0
-yamllint==1.35.1
+ruff>=0.9.10
+mypy>=1.15.0
+yamllint>=1.35.1
 types-PyYAML
 pandas-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pandas==2.2.3
-pytest==7.0.1
-pytest-xdist==3.8.0
+pandas>=2.2.3
+pytest>=7.0.1
+pytest-xdist>=3.8.0


### PR DESCRIPTION
## Process CHORE - Dependencies Policy Pinning Allignment

### Aligns dependency pinning across the GEMS ecosystem with an agreed policy:

Third-party dependencies → >= (flexible lower bound, allows patch/minor upgrades without manual bumps)
Specific/internal dependencies (antares-craft, gemspy, pypsa) → == (exact pin, ensures coordinated releases between GEMS components)

## Description

Six changes across two files:

**requirements.txt:**

pandas==2.2.3 → >=2.2.3
pytest==7.0.1 → >=7.0.1
pytest-xdist==3.8.0 → >=3.8.0


**requirements-dev.txt:**

ruff==0.9.10 → >=0.9.10
mypy==1.15.0 → >=1.15.0
yamllint==1.35.1 → >=1.35.1




## Checklist

- [x] Github Workflow Pass
- [x] Check web-site locally @GuillaumeMaistre 




