### PR TITLE
docs: add field types and fix value-condition bug in user guide

### DIFF
--- a/doc/user-guide/file-structure/data-series.md
+++ b/doc/user-guide/file-structure/data-series.md
@@ -8,7 +8,9 @@
 
 Data series provide the numerical input data for time-varying and scenario-varying parameters and they are stored in `csv` files.
 
-The filename (without extension) serves as the `id` of the data series. For instance, a file named `demand_profile.csv` defines a data series with the `id` `demand_profile`. This `id` is what users would use in the system file’s to instantiate parameter values.
+The filename (without extension) serves as the `id` of the data series. For instance, a file named `demand_profile.csv` defines a data series with the `id` `demand_profile`. This `id` is what users would use in the system file to instantiate parameter values.
+
+All cell values are **floating-point numbers**. Values are whitespace-separated (spaces or tabs); no header row should be present.
 
 ## Time-dependent series
 
@@ -31,7 +33,7 @@ Represent a value that varies by scenario, but is constant in time. The file sho
 10 22 55 42
 ```
 
-This would indicate the parameter’s value in scenario 1 is 10, scenario 2 is 60, 22.
+This would indicate the parameter’s value in scenario 1 is 10, scenario 2 is 22, and scenario 3 is 55.
 
 ## Time-and-scenario-dependent series
 

--- a/doc/user-guide/file-structure/library.md
+++ b/doc/user-guide/file-structure/library.md
@@ -50,18 +50,20 @@ All `id's` in the model library and system file must respect the following:
 
 ## Collections and key fields in library file
 
-Every library file must begin with the following header with optional `description`:
+Every library file must begin with the following header with optional `description` and `version`:
 
 ```yaml
 library:
   id: example_library
   description: "Example model library"
+  version: "1.0.0"
 ```
 
-| Element | Description |
-|------|--------------------------|
-| `id`| A unique identifier for the library. This `id` is used by system files to reference models from this library. It must be unique across all libraries that are used to build a system and must follow standard [naming rules](#rules-for-id-naming).|
-| `description` | *(Optional)* A human-readable description of the library’s content or purpose.|
+| Element | Type | Description |
+|------|------|--------------------------|
+| `id`| String | A unique identifier for the library. This `id` is used by system files to reference models from this library. It must be unique across all libraries that are used to build a system and must follow standard [naming rules](#rules-for-id-naming).|
+| `description` | String | *(Optional)* A human-readable description of the library’s content or purpose.|
+| `version` | String | *(Optional)* A version string for the library (e.g. `"1.0.0"`). Should be bumped whenever the library changes; see the corresponding `CHANGELOG` file.|
 
 ### Port Types
 
@@ -81,12 +83,12 @@ port-types:
         - id: field_2
 ```
 
-| Element | Description |
-|------|--------------------------|
-|`port-types`| A list of port types definitions that models can use for connecting to other models.|
-| `id`| Unique `id` for the port type within this library (must follow the naming rules and not conflict with other port type `id's` in the same library).|
-| `description` | *(Optional)* A human-readable description of the library’s content or purpose.|
-|`fields`| A list of fields carried by this port. Each field has an `id` (unique within the port type) that identifies a quantity carried by the port (e.g. a field might be power flow). A field holds a single floating number.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`port-types`| List | A list of port type definitions that models can use for connecting to other models.|
+| `id`| String | Unique `id` for the port type within this library. Must follow the [naming rules](#rules-for-id-naming) and must not conflict with other port type `id`s in the same library.|
+| `description` | String | *(Optional)* A human-readable description of the port type’s purpose.|
+|`fields`| List | A list of fields carried by this port. Each field has an `id` (unique within the port type) that identifies a scalar floating-point quantity exchanged through the port (e.g. a power flow value).|
 
 ### Models
 
@@ -174,20 +176,20 @@ A model is an abstract object, that will be instantiated once or several times i
 
 #### Unique Identifier and Description
 
-| Element | Description |
-|------|--------------------------|
-|`id`| A unique identifier for the model within a library. It must follow standard [naming rules](#rules-for-id-naming). System files reference the model by combining the library `id` and the model `id`.|
-| `description`| *(Optional)* Text description of the model.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | A unique identifier for the model within a library. Must follow the [naming rules](#rules-for-id-naming). System files reference the model by combining the library `id` and the model `id`.|
+| `description`| String | *(Optional)* Text description of the model.|
 
 #### Parameters
 
 A list of parameters that this model takes. Each parameter defines a configurable value for the model when it’s used in a system. For each parameter user can specify specify:
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique parameter identifier within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `time-dependent`| `true` or `false`. If `true`, this parameter can vary over the simulation timeline (meaning it will be associated with a time series input). If `false`, it’s treated as constant in time.|
-|`scenario-dependent`|`true` or `false`. If `true`, the parameter can have different values in different scenarios (i.e., it requires scenario-specific data). If `false`, it does not vary between scenarios.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique parameter identifier within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `time-dependent`| Boolean | `true` or `false`. If `true`, this parameter can vary over the simulation timeline (meaning it will be associated with a time series input). If `false`, it is treated as constant in time.|
+|`scenario-dependent`| Boolean | `true` or `false`. If `true`, the parameter can have different values in different scenarios (i.e., it requires scenario-specific data). If `false`, it does not vary between scenarios.|
 
 Together, these flags define how the parameter can be provided — as a single value, a time series, scenario-based data, or a matrix. For details on how parameter data is stored and referenced, see the [data-series](./data-series.md).
 
@@ -195,12 +197,12 @@ Together, these flags define how the parameter can be provided — as a single v
 
 A list of decision variables introduced by this model for the optimization problem. Each variable includes:
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique variable name within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `variable-type`| The type of variable: `continuous`, `integer`, or `binary`. This influences how the solver treats the variable (`continuous` vs. `integer programming`).|
-|`lower-bound`|*(Optional)* A mathematical expression for the variable’s lower bound (if not provided, defaults to -∞ for continuous/integer, or 0 for binary).|
-|`upper-bound`|*(Optional)* A mathematical expression for the variable’s upper bound (if not provided, defaults to +∞ for continuous/integer, or 1 for binary).|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique variable name within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `variable-type`| Enum | The type of variable: `continuous`, `integer`, or `binary`. This determines how the solver treats the variable.|
+|`lower-bound`| Number or Expression | *(Optional)* Lower bound for the variable. Can be a numeric literal or an expression using only model parameters and constants. Defaults to −∞ for `continuous`/`integer`, or `0` for `binary`.|
+|`upper-bound`| Number or Expression | *(Optional)* Upper bound for the variable. Can be a numeric literal or an expression using only model parameters and constants. Defaults to +∞ for `continuous`/`integer`, or `1` for `binary`.|
 
 Any expression used for bounds must use only constants or models parameters.
 
@@ -218,10 +220,10 @@ variables:
 
 A list of ports that model exposes to connect with other models. Each port has:
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique port name within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `type`| The port type (by `id`) that this port conforms to.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique port name within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `type`| String | The port type `id` that this port conforms to. Must match a port type defined in the [port-types](#port-types) collection of a library included in the system.|
 
 The port `type` must be one of those defined in the [port-types](#port-types) collection of a library included in the system.
 
@@ -229,20 +231,20 @@ The port `type` must be one of those defined in the [port-types](#port-types) co
 
 A collection of definitions describing the ports **emitted** by a model. Each entry associates one of the model’s variables, parameters, or linear expressions with a specific field of a port. When a model defines a port, it must provide definitions for all fields of that port.
 
-| Element | Description |
-|------|--------------------------|
-|`port`| The `id` of a port (as listed in the [ports section](#ports) of this model).|
-| `field`| The field `id` (as defined in the [port types](#port-types)) that is intended to be defined for this port.|
-|`definition`| An expression for the value of that field, using the model’s variables/parameters.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`port`| String | The `id` of a port listed in the [ports section](#ports) of this model.|
+| `field`| String | The field `id` as defined in the corresponding [port type](#port-types).|
+|`definition`| [Mathematical Expression](../mathematical-syntax.md) | A linear expression giving the value of that port field, using the model’s variables and/or parameters.|
 
 #### Constraints
 
 A list of internal constraints of a model. These are equations or inequalities that involve the model’s own variables, parameters. Each constraint has:
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique `id` for the constraint within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `expression`| A mathematical expression representing the constraint.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique `id` for the constraint within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `expression`| [Mathematical Expression](../mathematical-syntax.md#constraints) | An equation or inequality using the model’s variables and parameters.|
 
 An explicit example is provided by the `storage` model constraint defining the initial reservoir level:
 
@@ -258,10 +260,10 @@ Constraint **expression** must comply with the [**Mathematical Expression Syntax
 
 A list of external constraints that involve model’s ports (i.e., constraints that will bind this model’s behavior to other models when connected).
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique `id` for the constraint within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `expression`| A mathematical expression representing the constraint.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique `id` for the binding constraint within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `expression`| [Mathematical Expression](../mathematical-syntax.md#constraints) | An equation or inequality that may use [port operators](../mathematical-syntax.md#port-operator) to aggregate expressions from connected components.|
 
 Binding constraints are defined in the same manner as internal constraints, but they may include [port operators](../mathematical-syntax.md#port-operator), which aggregate linear expressions emitted through a port.
 
@@ -279,10 +281,10 @@ A detailed, step-by-step illustration of how binding constraints are constructed
 
 An `objective contribution` is a linear expression that represents a cost or penalty associated with a model component. During model assembly, all objective contributions defined across all instantiated components are **automatically aggregated** to form the **global objective function** of the optimisation problem. By convention, the optimisation problem is assumed to be a **minimisation** problem.
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique `id` for the constraint within the model. It must follow standard [naming rules](#rules-for-id-naming).|
-| `expression`| A mathematical expression representing the constraint.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique `id` for the objective contribution within the model. Must follow the [naming rules](#rules-for-id-naming).|
+| `expression`| [Mathematical Expression](../mathematical-syntax.md) | A linear expression representing a cost or penalty term. All contributions across all components are summed to form the global minimisation objective.|
 
 ```yaml
 objective-contributions:
@@ -298,10 +300,10 @@ The `extra-outputs` section allows each model to define additional calculated ou
 
 Each entry under `extra-outputs` must contain:
 
-| Field | Description |
-|--------------|-----------------|
-| `id` | Unique identifier for the extra output within the model. Must follow standard ID rules (lowercase, alphanumeric, underscores). |
-| `expression` | A mathematical expression computed after optimization. Can use variables, parameters, and port fields. Must be linear and evaluable from optimal values. |
+| Field | Type | Description |
+|------|------|-----------------|
+| `id` | String | Unique identifier for the extra output within the model. Must follow the [naming rules](#rules-for-id-naming). |
+| `expression` | [Mathematical Expression](../mathematical-syntax.md) | A linear expression evaluated from optimal variable values after the solve. May use variables, parameters, and [direct port field access](../mathematical-syntax.md#direct-port-field-usage) (unlike constraints). |
 
 Unlike in constraints, [direct port field usage](../mathematical-syntax.md#direct-port-field-usage) **is allowed** in `extra-outputs`.
 

--- a/doc/user-guide/file-structure/scenario-builder.md
+++ b/doc/user-guide/file-structure/scenario-builder.md
@@ -26,6 +26,12 @@ Each line in the `modeler-scenariobuilder.dat` file defines a single mapping usi
 scenario_group_id, scenario = time_series_index
 ```
 
+| Token | Type | Description |
+|-------|------|-------------|
+| `scenario_group_id` | String | Matches the `scenario-group` `id` assigned to a component in the [system file](system.md#components). |
+| `scenario` | Integer (≥ 0) | 0-based index of the Monte Carlo scenario. |
+| `time_series_index` | Integer (≥ 1) | 1-based column index in the data series file to use for this scenario. |
+
 ## Example
 
 ```text

--- a/doc/user-guide/file-structure/system.md
+++ b/doc/user-guide/file-structure/system.md
@@ -37,46 +37,56 @@ In this example, the system file defines a system with two model libraries, `my_
 
 The system `my_system` instantiates two components: `load_1`, which is an instance of the `load` model defined in `my_library_1`, and `bus_1`, which is an instance of the `bus` model defined in `my_library_2`. The `load_1` component assigns a time-dependent parameter `load`, whose value is provided by the data series identified as `demand_profile`.
 
-The `connections` section specifies how components are linked. In this case, the `balance_port` port of `load_1` is connected to the `balance_port` port of `bus_1`, indicating that the load is connected to the node
+The `connections` section specifies how components are linked. In this case, the `balance_port` port of `load_1` is connected to the `balance_port` port of `bus_1`, indicating that the load is connected to the node.
+
+The top-level fields of a system file are:
+
+| Element | Type | Description |
+|------|------|--------------------------|
+| `id` | String | A unique identifier for the system. Must follow the [naming rules](library.md#rules-for-id-naming).|
+| `description` | String | *(Optional)* A human-readable description of the system.|
+| `model-libraries` | String | *(Optional)* Comma-separated list of library IDs whose models are used in this system (e.g. `my_library_1, my_library_2`). Must match the `id` fields of the library files available to the simulation.|
+| `components` | List | The list of component instantiations in the system.|
+| `connections` | List | The list of port connections between components.|
 
 ## Components
 
 The system file describes the energy system to be simulated. Each component defined in the system represents a concrete instantiation of a model from one of the referenced libraries. For every component, the following fields are specified:
 
-| Element | Description |
-|------|--------------------------|
-|`id`| Unique identifier for the component within this system.|
-| `model` | Specifies which model this component instantiates The format is `library_id.model_id`.|
-|`scenario-group`|The `id` of the scenario group this component belongs to. |
-|`parameters`|Collection of values assigned to the model’s parameters. All parameters defined by the model must be assigned a value.|
+| Element | Type | Description |
+|------|------|--------------------------|
+|`id`| String | Unique identifier for the component within this system. Must follow the [naming rules](library.md#rules-for-id-naming).|
+| `model` | String | Specifies which model this component instantiates. The format is `library_id.model_id`.|
+|`scenario-group`| String | *(Optional)* The `id` of the scenario group this component belongs to. Used to map Monte Carlo scenarios to data series columns via the [scenario builder](scenario-builder.md).|
+|`parameters`| List | *(Optional)* Collection of values assigned to the model’s parameters. All parameters defined by the model must be assigned a value.|
 
 ### Parameters
 
 For each parameter definition, the following fields must be provided:
 
-| Element | Description |
-|------|--------------------------|
-| `id`| The `id` of the parameter, as defined by the model.|
-| `time-dependent` | `true` or `false`, indicates whether the parameter depends on time or is constant across the whole simulation horizon. If the model parameter is not time-dependent, this can't be set to true.|
-|`scenario-dependent`|`true` or `false`, indicates whether the parameter changes depending on the simulated scenario, or is the same for all scenarios. If the model parameter is not scenario-dependent, this can't be set to true. |
-|`value`|Value assigned to the parameter.|
+| Element | Type | Description |
+|------|------|--------------------------|
+| `id`| String | The `id` of the parameter, as defined by the model.|
+| `time-dependent` | Boolean | `true` or `false`. Indicates whether the parameter varies over time. Cannot be set to `true` if the corresponding model parameter is not declared time-dependent.|
+|`scenario-dependent`| Boolean | `true` or `false`. Indicates whether the parameter changes across scenarios. Cannot be set to `true` if the corresponding model parameter is not declared scenario-dependent.|
+|`value`| Number or String | Value assigned to the parameter (see below).|
 
 For each parameter, the `value` field should be defined as follows:
 
-- If `time-dependent : false` and `scenario-dependent : true`, the numerical value of the parameter (`float` or `integer`)
+- If `time-dependent: false` and `scenario-dependent: false`, the numerical value of the parameter (`float` or `integer`).
 
-- Else, the `id` of a `time-dependent` data series
+- Otherwise (when at least one of `time-dependent` or `scenario-dependent` is `true`), the `id` of a data series stored in the `data-series` directory. See [data series](./data-series.md) for file format details.
 
 ## Connections
 
 A list of connections between component ports. Each connection entry defines a link between two components’ ports, allowing them to interact.
 
-|Element | Description |
-|------|--------------------------|
-| `component1`| The `id` of the first component being connected.|
-| `component2` | The `id` of the second component being connected.|
-|`port1`| The port `id` on `component1`. |
-|`port2`|The port `id` on `component2`.|
+|Element | Type | Description |
+|------|------|--------------------------|
+| `component1`| String | The `id` of the first component being connected.|
+| `component2` | String | The `id` of the second component being connected.|
+|`port1`| String | The port `id` on `component1`.|
+|`port2`| String | The port `id` on `component2`.|
 
 The two ports being connected must be of the same port type.
 


### PR DESCRIPTION
Add an explicit Type column to all field tables in library.md, system.md,
data-series.md, and scenario-builder.md so readers can see at a glance
whether a field accepts a String, Boolean, Enum, Number, or Mathematical
Expression — following the style already used in solver-optimization.md.

Also:
- Document the missing `version` field in the library header (present in
  all real library YAMLs but absent from the docs).
- Fix an inverted condition in system.md: the `value` field is a number
  when BOTH time-dependent and scenario-dependent are false, not when
  scenario-dependent is true.
- Add a top-level field table to system.md (id, description,
  model-libraries, components, connections).
- Add a token-type table to scenario-builder.md.
- Fix a copy-paste error in data-series.md ("scenario 2 is 60, 22").
- Clarify that data series cell values are floating-point numbers.

https://claude.ai/code/session_01PAxkYgxjnRiunwbpHmxdgL