### PR TITLE
(PR63) Chore CICD - Path Blocker

### DIFF
--- a/.github/workflows/update-library-checksums.yml
+++ b/.github/workflows/update-library-checksums.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'release/**'
       - 'hotfix/**'
-    paths:
-      - 'libraries/*.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Chore

Remove paths filter from update-library-checksums workflow

### Why

The path filter blocked the workflow if the last PR merged into a release or hotfix branch didn't touch libraries/*.yml. This created a reliability gap at release time — the library could have been updated in an earlier PR during the release cycle, leaving the .sha256 files stale for the final release artifact.

The workflow's internal logic already handles the "nothing changed" case correctly: it compares the current hash against the stored one and only commits if there is an actual difference. The path filter was a redundant and less reliable guard that could cause incorrect skips.

Removing it is low-risk since release and hotfix branches have very few commits by design (typically 3–5), so the overhead of running the workflow on every push is negligible.

### What stays the same

The workflow still only triggers on release/** and hotfix/** branches, and still skips the commit step if no checksums have changed.

