### PR TITLE
Simplify and deduplicate the Custom Sets and Indexing proposal

### DIFF
--- a/doc/user-guide/file-structure/data-series.md
+++ b/doc/user-guide/file-structure/data-series.md
@@ -63,9 +63,9 @@ The new tidy/long, headered CSV format below applies exclusively to parameters t
 A parameter declared `indexed-by` a [custom set](./library.md#sets) — whether a local (model-level)
 or [global (library-level)](./library.md#library-level-sets) set — cannot use the positional matrix
 formats above: a third (or later) dimension cannot be expressed by shape alone without an arbitrary
-stacking convention, and an enumerated set's elements are *named*, not positional, so a plain matrix
-cannot carry their names. Such parameters instead use a **tidy/long CSV format, with a header row**
-— unlike every other data series, which has no header:
+stacking convention, and a set instantiated with named elements in `system.yml` has *named*, not
+positional, elements, so a plain matrix cannot carry their names. Such parameters instead use a
+**tidy/long CSV format, with a header row** — unlike every other data series, which has no header:
 
 ```csv
 segment,time,scenario,value
@@ -84,8 +84,8 @@ segment,value
 2,60.0
 ```
 
-For a parameter indexed by an enumerated set, the column holds element names instead of integer
-positions:
+For a parameter indexed by a set `system.yml` instantiated with named elements (an explicit list, e.g.
+`elements: [gas, coal, oil]`), the column holds those names instead of integer positions:
 
 ```csv
 fuel,value
@@ -114,9 +114,10 @@ segment,fuel,time,scenario,value
 0,coal,0,0,9.2
 ```
 
-Neither a global nor a local set ever gives concrete `elements`/`cardinality` in the library or model —
-both always come from `system.yml`: once, study-wide, in [Global Sets](./system.md#global-sets) for a
-global set, or per component, in [Local Sets](./system.md#local-sets) for a local enumerated set. The
-library/model alone never tells a data-series author the concrete element list to use — the column's
-values must match exactly whatever the relevant `system.yml` instantiation declares.
+A data-series column's values must match exactly whatever `system.yml` declares for that set —
+[Global Sets](./system.md#global-sets) or [Local Sets](./system.md#local-sets) — whether that
+instantiation was an explicit list or a range shorthand (a range-instantiated set's column simply
+holds the resulting integers); the library/model alone never tells a data-series author the concrete
+element list to use, since neither ever gives a set's concrete `elements` itself (see
+[library.md's Sets](./library.md#sets)).
 

--- a/doc/user-guide/file-structure/library.md
+++ b/doc/user-guide/file-structure/library.md
@@ -54,17 +54,18 @@ All `id's` in the model library and system file must respect the following:
 - Only lower-case is allowed
 
 !!! warning "Design proposal — not yet implemented"
-    A local [set](#sets)'s `id` must not collide with any parameter or variable `id` within the same
-    model, or with the reserved literal `t`. **A global (library-level) set's `id` must likewise never
-    be the reserved literal `t`** — it is just as usable bare, in any model in the library, as a local
-    set's id is, so the same ambiguity applies.
+    A local [set](#sets)'s `id` must not collide with any [global (library-level)
+    set](#library-level-sets) `id` visible in the same library — since `indexed-by: x` (or a bare
+    reference to `x` inside `{...}`) would otherwise be ambiguous between the two. This is the only
+    id-collision rule custom sets add: a set is only ever looked up in two places — inside `{...}`
+    right after an identifier, or as the value of `indexed-by:` — and both positions only ever accept a
+    set `id`, never a parameter or variable `id`, so **parameter and variable ids are free to collide
+    with set ids** (local or global) without any ambiguity. This is not recommended, though: even
+    though the parser never confuses the two, a reader has to hold both meanings in their head — prefer
+    giving a set a distinct `id` from any parameter or variable in scope.
 
-    More generally: **no locally-declared identifier in a model — a parameter, variable, local set,
-    port, constraint, binding-constraint, objective-contribution, or extra-output `id` — may collide
-    with any [global (library-level) set](#library-level-sets) `id` visible in that library.** A
-    global set's `id` is usable bare from inside any model in the library (via `indexed-by`, or as a
-    bare current-position reference) without that model declaring anything locally, so any local `id`
-    that happens to match one creates the same kind of ambiguity a local-set/parameter collision would.
+    `t` remains reserved and may never be used as a set `id` (local or global), exactly like it's
+    already reserved for other identifiers in this syntax.
 
     These rules are part of the
     [Custom Sets and Indexing](../mathematical-syntax.md#custom-sets-and-indexing-proposed) proposal —
@@ -97,56 +98,34 @@ library:
 
 The `sets` collection, a sibling of `port-types` and `models`, declares **global** custom index sets
 — shared by every model and port-type field in this library that references them. This is the only
-kind of custom set that may cross a port: a [port-type field](#port-types)'s `indexed-by` may only
-name a global set, and the argument passed to `sum_connections` inside a
-[binding constraint](#binding-constraints) may only be indexed by one, since every component
-connecting through a port must agree on the exact same index domain (see
-[Why the distinction matters](../mathematical-syntax.md#why-the-distinction-matters)). This does
-**not** restrict a binding constraint as a whole — it may still freely reference the model's own local
-sets in parts of its expression that don't cross the port. Model-level, per-component-varying sets are
-declared separately — see [Sets](#sets) under Models below.
+kind of custom set that may cross a port (see [Port fields and custom
+sets](../mathematical-syntax.md#port-fields-and-custom-sets) for the precise rules), since every
+component connecting through a port must agree on the exact same index domain (see [Why the
+distinction matters](../mathematical-syntax.md#why-the-distinction-matters)). Model-level,
+per-component-varying sets are declared separately — see [Sets](#sets) under Models below.
 
-This collection is **optional**. A [local set](#sets) (declared under Models, below) follows the
-identical "never given in the library" rule — the only difference between the two scopes is *who*
-supplies the concrete value and *how uniformly*: once, study-wide, for a global set, versus per
-component for a local set.
-
-A global set's concrete size or contents are **never** given in the library — only its `id`,
-`description`, and **kind** (`ordinal` or `enumerated`). This mirrors GEMS's existing pattern of the
-library declaring structure while the system file assigns concrete values (the same way a model
-declares that a parameter exists, but only `system.yml` gives it a value). The concrete `cardinality`
-(ordinal) or `elements` (enumerated) are always supplied exactly once, study-wide, in
-[`system.yml`'s Global Sets section](../system.md#global-sets) — see below.
+This collection is **optional**. A global set's concrete contents are **never** given in the library —
+only its `id` and an optional `description`; concrete `elements` are always supplied exactly once,
+study-wide, in [`system.yml`'s Global Sets section](../system.md#global-sets). A [local set](#sets)
+(declared under Models, below) follows the same shape, scoped to a single model instead — see there.
 
 ```yaml
 library:
   id: example_library
   sets:
     - id: fuel
-      kind: enumerated
     - id: segment_count_set
-      kind: ordinal
 ```
 
 | Element | Type | Description |
 |------|------|--------------------------|
 |`id`| String | Unique set identifier within the library. Must follow the [naming rules](#rules-for-id-naming).|
 | `description`| String | *(Optional)* A human-readable description of the set's purpose.|
-|`kind`| Enum | `ordinal` or `enumerated`. Determines which indexing forms are valid against this set in expressions (see below) — the concrete size/elements are resolved later, in `system.yml`, so this is the only thing the library itself needs to know.|
 
-Because a global set's `elements` are never known at library-authoring time, **bare named-element
-access (e.g. `X{gas}`) is never valid against a global set inside library expressions** — a model may
-only use ordinal-style access against a global set: the bare set-id for the current position
-(`X{fuel}`), a relative shift (`X{fuel+1}`), or an explicit integer position (`X{0}`). This holds
-regardless of `kind`: `enumerated` still means "named, ordered elements" once `system.yml` resolves it,
-it just means library expressions can only reach those elements by position, never by name. A [local
-set](#sets) (under Models, below) follows the identical rule — its `elements` are likewise never given
-in the model, so named access is never valid there either.
-
-**Recommended practice** (a `system.yml`-level concern now, since that's the only place a global set's
-concrete contents ever exist): make each study's instantiation *universal* — the superset of every
-element that could ever be relevant across the whole system — and express per-component variation
-through data (e.g. a `0` capacity/bound for unused elements) rather than through differing membership.
+See [Indexing expressions](../mathematical-syntax.md#indexing-expressions) for why library/model
+expressions can only ever access a set's elements positionally (never by name). See [System — Global
+Sets](../system.md#global-sets) for how `system.yml` instantiates `elements` and the recommended
+practice for instantiating a global set.
 
 ### Port Types
 
@@ -172,31 +151,6 @@ port-types:
 | `id`| String | Unique `id` for the port type within this library. Must follow the [naming rules](#rules-for-id-naming) and must not conflict with other port type `id`s in the same library.|
 | `description` | String | *(Optional)* A human-readable description of the port type’s purpose.|
 |`fields`| List | A list of fields carried by this port. Each field has an `id` (unique within the port type) that identifies a scalar floating-point quantity exchanged through the port (e.g. a power flow value).|
-
-!!! warning "Design proposal — not yet implemented"
-    A field may declare `indexed-by`, referencing one or more [library-level set](#library-level-sets)
-    `id`s (a single `id`, or a list for a field indexed by more than one set), to mark the field as
-    carrying a custom-set dimension (never a model-level set — see
-    [Port fields and custom sets](../mathematical-syntax.md#port-fields-and-custom-sets)):
-    ```yaml
-    port-types:
-      - id: multi_fuel_port
-        fields:
-          - id: flow
-            indexed-by: fuel
-    ```
-    A field's `indexed-by` list can name more than one global set, for a **multidimensional** port
-    field:
-    ```yaml
-    port-types:
-      - id: multi_fuel_multi_region_port
-        fields:
-          - id: flow
-            indexed-by: [fuel, region]
-    ```
-    Every set in the list must be global — since a port field can never reference a model-level set at
-    all, this holds dimension by dimension; there is no partial or mixed case. Not yet implemented in
-    [GemsPy](../../index.md).
 
 ### Models
 
@@ -333,44 +287,28 @@ variables:
     full expression-syntax proposal this schema supports.
 
 (Optional) A list of **local** custom index sets declared by this model — usable to index this
-model's own `parameters` and `variables` (via the new `indexed-by` field described below) and to
-index its `constraints`, `binding-constraints`, `objective-contributions`, and `extra-outputs`. Local
-sets may vary per component but are not visible outside this model. A model may also use a
-[library-level set](#library-level-sets) directly via `indexed-by`, without declaring anything here —
-declare a local set only when the index genuinely needs to vary per component or stay internal to
-this model; see [Why the distinction matters](../mathematical-syntax.md#why-the-distinction-matters).
+model's own `parameters` and `variables` via the `indexed-by` field described below. Local sets may
+vary per component but are not visible outside this model. A model may also use a [library-level
+set](#library-level-sets) directly via `indexed-by`, without declaring anything here — declare a local
+set only when the index genuinely needs to vary per component or stay internal to this model; see
+[Why the distinction matters](../mathematical-syntax.md#why-the-distinction-matters).
 
-Exactly like a [library-level set](#library-level-sets), **a local set's concrete contents are never
-given in the model** — only its `id`, `description`, and `kind`. The concrete value is always assigned
-in `system.yml`: per component, for both kinds (an ordinal set's `cardinality` names a scalar
-parameter, whose *value* is assigned per component through the ordinary parameter-assignment
-mechanism; an enumerated set's `elements` are assigned per component directly, in `system.yml`'s
-[Local Sets](../system.md#local-sets) list).
+Exactly like a [library-level set](#library-level-sets) (see above for why a set never gives its
+concrete contents here), a local set's `elements` are assigned per component instead, in
+`system.yml`'s [Local Sets](../system.md#local-sets) list.
 
 | Element | Type | Description |
 |------|------|--------------------------|
-|`id`| String | Unique set identifier within the model. Must follow the [naming rules](#rules-for-id-naming) (including the naming-collision constraints against parameters/variables/`t`/global sets described there).|
+|`id`| String | Unique set identifier within the model. Must follow the [naming rules](#rules-for-id-naming) (including the local-vs-global-set collision rule described there).|
 | `description`| String | *(Optional)* A human-readable description of the set's purpose.|
-|`kind`| Enum | `ordinal` or `enumerated` — mandatory, same as for a [library-level set](#library-level-sets).|
-|`cardinality`| Parameter `id` | *(`kind: ordinal` only)* The `id` of a scalar, non-time/scenario-dependent, non-set-indexed parameter of this model — never a literal integer. That parameter's *value*, assigned per component via the ordinary parameter-assignment mechanism (see [System — Parameters](../system.md#parameters)), gives that component's 0-based set size `0 .. cardinality-1`. Required for `kind: ordinal`; must be absent for `kind: enumerated`.|
-
-There is no `elements` field here — an enumerated local set's concrete elements are always supplied
-per component in [`system.yml`'s Local Sets](../system.md#local-sets) list, never in the model.
 
 ```yaml
 models:
   - id: multi_segment_storage
-    parameters:
-      - id: segment_count
-        time-dependent: false
-        scenario-dependent: false
     sets:
       - id: segment
         description: "Price segments of the storage's marginal-value curve"
-        kind: ordinal
-        cardinality: segment_count   # names a scalar parameter; its value is assigned per component
       - id: operating_mode
-        kind: enumerated             # elements are supplied per component in system.yml
 ```
 
 To mark a parameter or variable as indexed by one (or more) of these sets, add an `indexed-by`
@@ -395,10 +333,8 @@ variables:
     variable-type: continuous
 ```
 
-The same `indexed-by` field applies to `constraints`, `binding-constraints`,
-`objective-contributions`, and `extra-outputs`, to force unfolding over a set even when none of the
-constraint's own terms are set-indexed — see
-[Indexing a constraint explicitly](../mathematical-syntax.md#indexing-a-constraint-explicitly-and-referencing-the-index-value-itself).
+`indexed-by` exists only on `parameters` and `variables` — `constraints`, `binding-constraints`,
+`objective-contributions`, and `extra-outputs` never declare it.
 
 #### Ports
 
@@ -420,12 +356,6 @@ A collection of definitions describing the ports **emitted** by a model. Each en
 |`port`| String | The `id` of a port listed in the [ports section](#ports) of this model.|
 | `field`| String | The field `id` as defined in the corresponding [port type](#port-types).|
 |`definition`| [Mathematical Expression](../mathematical-syntax.md) | A linear expression giving the value of that port field, using the model’s variables and/or parameters.|
-
-!!! warning "Design proposal — not yet implemented"
-    If the port field declares `indexed-by` (see [Port Types](#port-types)), this `definition`'s
-    expression must produce a value whose inferred indexing matches it exactly — see
-    [Port fields and custom sets](../mathematical-syntax.md#port-fields-and-custom-sets). Not yet
-    implemented in [GemsPy](../../index.md).
 
 #### Constraints
 
@@ -456,14 +386,6 @@ A list of external constraints that involve model’s ports (i.e., constraints t
 | `expression`| [Mathematical Expression](../mathematical-syntax.md#constraints) | An equation or inequality that may use [port operators](../mathematical-syntax.md#port-operator) to aggregate expressions from connected components.|
 
 Binding constraints are defined in the same manner as internal constraints, but they may include [port operators](../mathematical-syntax.md#port-operator), which aggregate linear expressions emitted through a port.
-
-!!! warning "Design proposal — not yet implemented"
-    `sum_connections(port.field{s})` is well-defined for any custom set `s`, because a port field can
-    only be `indexed-by` a [library-level (global) set](#library-level-sets) — every component
-    connecting through that port type necessarily shares the exact same set, so no additional runtime
-    guard is needed beyond that schema-level restriction. See
-    [Port fields and custom sets](../mathematical-syntax.md#port-fields-and-custom-sets). Not yet
-    implemented in [GemsPy](../../index.md).
 
 An explicit example is provided by the `bus` model implementing the energy balance constraint (**First Kirchhoff Law**):
 

--- a/doc/user-guide/file-structure/system.md
+++ b/doc/user-guide/file-structure/system.md
@@ -113,24 +113,19 @@ system:
     [Custom Sets and Indexing](../mathematical-syntax.md#custom-sets-and-indexing-proposed) proposal.
     It is not yet implemented in [GemsPy](../../index.md).
 
-(Required whenever a model declares a **local**, model-level [enumerated set](../library#sets)) A
-model never gives an enumerated local set's concrete `elements` itself (see [Sets](../library#sets)
-under Models) — every component instantiating that model must supply the set's concrete element list
-here, mirroring how [Properties](#properties) values are supplied per component while their keys are
-declared in the model. This mechanism is not needed for **ordinal** local sets, whose size varies per
-component through the ordinary [parameter](#parameters) assignment mechanism above instead (a local
-ordinal set's `cardinality` names a scalar parameter, and that parameter's value is what's assigned
-here — there is no separate `sets:` entry for it), nor for [global sets](#global-sets), which are
-instantiated once, study-wide, in a different top-level section (see [Global
-Sets](#global-sets) below and
-[Why the distinction matters](../mathematical-syntax.md#why-the-distinction-matters)).
+(Required whenever a model declares a **local**, model-level [set](../library#sets) — see
+[library.md's Sets](../library.md#sets) for why a local set never gives its concrete `elements`
+itself) Every component instantiating that model must supply the set's concrete element list here,
+mirroring how [Properties](#properties) values are supplied per component while their keys are
+declared in the model. This is not needed for [global sets](#global-sets), which are instantiated
+once, study-wide, in a different top-level section instead (see [Global Sets](#global-sets) below).
 
 Each set entry contains:
 
 | Element | Type | Description |
 |------|------|--------------------------|
-| `id` | String | The set key name, matching an enumerated set declared in the [model's local sets](../library#sets). |
-| `elements` | List of strings | The ordered list of named elements this component uses for that set. |
+| `id` | String | The set key name, matching a set declared in the [model's local sets](../library#sets). |
+| `elements` | List, or range shorthand | The ordered elements this component uses for that set — same two forms (explicit list or `S..E` range shorthand) as for a [global set](#global-sets); see there for the full explanation. |
 
 ```yaml
 system:
@@ -140,6 +135,11 @@ system:
       sets:
         - id: zone
           elements: [north, south]
+    - id: my_storage
+      model: mylib.multi_segment_storage
+      sets:
+        - id: segment
+          elements: 0..3        # shorthand for [0, 1, 2, 3]
 ```
 
 ## Global Sets
@@ -151,43 +151,48 @@ system:
 
 (Required whenever any used library declares global sets) A top-level `sets` collection — a sibling of
 `components` and `connections` — that instantiates **every** [library-level global
-set](../library.md#library-level-sets) declared by any library this system uses. A library never gives
-a global set's concrete size or contents itself (see [Library-Level
-Sets](../library.md#library-level-sets)) — `system.yml` is the **only** place that ever does, and it
-must do so for every one of them, not just some. This instantiation applies **once, uniformly, to the
-whole study** — never per component — because every component connecting through a port that uses this
-set must agree on the exact same index domain; a per-component override would defeat that guarantee
-(see [Why the distinction matters](../mathematical-syntax.md#why-the-distinction-matters)). This
-mirrors how `--duration`/`--scenarios` fix the time and scenario dimensions once for an entire run
-rather than per component.
+set](../library.md#library-level-sets) declared by any library this system uses (see [library.md's
+Library-Level Sets](../library.md#library-level-sets) for why a global set never gives its concrete
+contents itself). It must do so for every one of them, not just some. This instantiation applies
+**once, uniformly, to the whole study** — never per component — because every component connecting
+through a port that uses this set must agree on the exact same index domain; a per-component override
+would defeat that guarantee (see [Why the distinction
+matters](../mathematical-syntax.md#why-the-distinction-matters)). This mirrors how
+`--duration`/`--scenarios` fix the time and scenario dimensions once for an entire run rather than per
+component.
 
 Each set entry contains:
 
 | Element | Type | Description |
 |------|------|--------------------------|
 | `id` | String | The set key name, matching a [library-level set](../library.md#library-level-sets) declared by one of this system's libraries. |
-| `cardinality` | Integer | *(Sets declared `kind: ordinal` in the library)* The set's size, as an integer literal. |
-| `elements` | List of strings | *(Sets declared `kind: enumerated` in the library)* The ordered list of named elements. |
+| `elements` | List, or range shorthand | The set's concrete, ordered elements — see the two accepted forms below. |
+
+`elements` accepts one of two forms — the same two forms a [local set](#local-sets) accepts:
+
+- **An explicit list** — names (`elements: [gas, coal, oil]`) or numbers (`elements: [10, 20, 30]`,
+  including non-consecutive ones).
+- **A range shorthand**, reusing the `..` token from the [time range summation
+  operator](../mathematical-syntax.md#time-operators-and-indexing): `elements: 0..3` is shorthand for
+  the explicit list `[0, 1, 2, 3]` — inclusive of both ends. `S` and `E` must be plain non-negative
+  integers (`S <= E`; `S == E` is legal, for a single-element set).
 
 ```yaml
 system:
   id: my_system
   model-libraries: example_library
   sets:
-    - id: fuel                      # kind: enumerated in the library
+    - id: fuel
       elements: [gas, coal, oil]
-    - id: segment_count_set         # kind: ordinal in the library
-      cardinality: 5
+    - id: segment_count_set
+      elements: 0..4        # shorthand for [0, 1, 2, 3, 4]
   components:
     - id: gen_1
       model: example_library.multi_fuel_generator
 ```
 
-Whether an entry gives `cardinality` or `elements` must match the `kind` (`ordinal`/`enumerated`) that
-library declared for that set — supplying the wrong shape (e.g. `elements` for a set the library marked
-`kind: ordinal`) is an error. Every global set declared by any library used in the system must appear
-here exactly once; a library using this feature with no matching entry in `system.yml` is an error at
-study-instantiation time.
+Every global set declared by any library used in the system must appear here exactly once; a library
+using this feature with no matching entry in `system.yml` is an error at study-instantiation time.
 
 **Recommended practice:** instantiate each global set as *universal* — the superset of every element
 that could ever be relevant across the whole system (e.g. `elements: [gas, coal, oil, biomass,

--- a/doc/user-guide/mathematical-syntax.md
+++ b/doc/user-guide/mathematical-syntax.md
@@ -110,6 +110,14 @@ When using a port field in an expression, the same dependency rules apply: if th
 
 If a port’s expressions need to be used in a time-independent manner (for example, when calculating a sum over the full time horizon), an aggregator must be applied to remove the time index. See the section on the [**Time Summation Operator**](#time-summation-full-horizon-sumx) for details. A practical implementation is provided in [`basic_models_library.yml`](https://github.com/AntaresSimulatorTeam/GEMS/blob/main/libraries/basic_models_library.yml) where the `emission_port` is used to support pollutant-related constraints.
 
+!!! warning "Design proposal — not yet implemented"
+    The same inference applies to a third dimension, too: if a port field's defining expression is
+    indexed by a [custom set](#custom-sets-and-indexing-proposed) (deduced the same way, from the
+    parameters/variables the expression depends on), the field carries that dimension — no separate
+    declaration is needed, exactly like time and scenario. See [Port fields and custom
+    sets](#port-fields-and-custom-sets) for the two rules this inference must additionally satisfy
+    before a field can be aggregated across connections. Not yet implemented in [GemsPy](../index.md).
+
 ### Port Operator
 
 A single port on a model can have multiple connections feeding into it (multiple components can connect to the same port of this component). To aggregate all incoming values of a port field, **Mathematical Expression Syntax**  provides a special operator:
@@ -211,19 +219,11 @@ element."
 Custom sets come in two scopes, and the right choice depends on whether the set ever needs to be
 shared across connected components (through a port) or stays purely internal to one model:
 
-- **Local sets** — declared at [model level](#declaring-a-local-model-level-set); may vary per
+- **Local sets** — declared at [model level](file-structure/library.md#sets); may vary per
   component; never visible outside the model that declares them.
-- **Global sets** — declared once at [library level](#declaring-a-global-library-level-set); visible
+- **Global sets** — declared once at [library level](file-structure/library.md#library-level-sets); visible
   to every model and port-type field in that library; **required** whenever a set needs to cross a
   port, since every component connecting through that port must agree on the exact same index domain.
-
-**Both scopes follow the same rule for where a set's concrete contents live: never in the library.** A
-model or library only ever declares that a set exists (its `id` and **kind** — `ordinal` or
-`enumerated`); the concrete `cardinality`/`elements` are always assigned in `system.yml` — once,
-study-wide, for a global set, or per component, for a local set. This mirrors exactly how GEMS already
-treats parameters and properties (declared in the library, valued in the system file), applied to sets
-too, and it means named-element access (`X{gas}`) is never valid in library expressions for *any* set
-— see [Indexing expressions](#indexing-expressions) below.
 
 ### Why the distinction matters
 
@@ -231,7 +231,7 @@ Time and scenario are *global* dimensions: every component in a study shares the
 and scenario count, which is exactly why results can be laid out on one shared array indexed by
 (component, time, scenario) in [GemsPy](../index.md)'s solver implementation. A **local** set is
 inherently *ragged*: different components of the same model can have a
-different cardinality or different named elements. A ragged dimension cannot be safely combined
+different number of elements, or the same number under different names. A ragged dimension cannot be safely combined
 across components — there is no well-defined meaning to summing "element 0" of one component's list
 against "element 0" of a different component's list if the lists don't actually agree. That is why
 local sets may only be used internally, within the model that declares them, and why anything that
@@ -239,196 +239,58 @@ needs to cross a port must use a **global** set instead — a global set is guar
 every component that can ever connect through it, so it behaves like time/scenario: uniform, not
 ragged.
 
-### Declaring a local (model-level) set
-
-A model declares its local custom sets in a `sets` collection, alongside `parameters` and `variables`.
-Every local set states its **kind** (`ordinal` or `enumerated`) — its concrete contents are never
-given here, exactly like a global set (see below):
-
-- **Ordinal (range) set** (`kind: ordinal`) — 0-based integer positions `0 .. cardinality-1`
-  (consistent with time's 0-based convention). `cardinality` names a scalar parameter of this model —
-  never a literal — whose *value* (assigned per component, via the ordinary parameter-assignment
-  mechanism in `system.yml`, exactly like any other parameter) gives that component's set size. This
-  is how a local ordinal set varies per component: no new mechanism beyond the one parameters already
-  use. The referenced parameter must itself be scalar (non-time/scenario-dependent) and must not
-  itself be `indexed-by` anything, to avoid a circular "set size depends on another set" dependency.
-- **Enumerated (named) set** (`kind: enumerated`) — named, ordered elements. The concrete `elements`
-  list is always supplied per component in `system.yml`'s `sets:` list (never in the model), mirroring
-  how [Properties](file-structure/system.md#properties) values are supplied per component while their
-  keys are declared in the model — see [System — Local Sets](file-structure/system.md#local-sets).
-
-```yaml
-models:
-  - id: multi_segment_storage
-    parameters:
-      - id: segment_count
-        time-dependent: false
-        scenario-dependent: false
-    sets:
-      - id: segment
-        description: "Price segments of the storage's marginal-value curve"
-        kind: ordinal
-        cardinality: segment_count   # names a scalar parameter; its value is assigned per component
-      - id: operating_mode
-        kind: enumerated             # elements are supplied per component in system.yml
-```
-
-### Declaring a global (library-level) set
-
-A library declares its global custom sets in a `sets` collection, a sibling of `port-types` and
-`models` — not nested inside any one of them, since a global set may be shared by several models and
-port types at once. **A global set's concrete size or contents are never given in the library** —
-only its `id`, `description`, and **kind** (`ordinal` or `enumerated`), matching GEMS's existing
-pattern of the library declaring structure while the system file assigns concrete values (the same way
-a model declares that a parameter exists, but only `system.yml` gives it a value). The concrete
-`cardinality` (ordinal) or `elements` (enumerated) are always supplied exactly once, study-wide, in
-`system.yml`'s new top-level [`sets`](file-structure/system.md#global-sets) section — never given in
-the library, and never per-component (see [Why the distinction matters](#why-the-distinction-matters)
-above for why a per-component override would defeat the purpose of a global set):
-
-```yaml
-library:
-  id: example_library
-  sets:
-    - id: fuel
-      kind: enumerated
-    - id: segment_count_set
-      kind: ordinal
-  port-types:
-    - id: multi_fuel_port
-      fields:
-        - id: flow
-        # see "Port fields and custom sets" below
-  models:
-    - id: multi_fuel_generator
-      parameters:
-        - id: gen_capacity
-          indexed-by: fuel   # references the global set directly, no local declaration needed
-          time-dependent: false
-          scenario-dependent: false
-```
-
-Because a global set's `elements` are never known at library-authoring time, **bare named-element
-access (e.g. `X{gas}`) is never valid against a global set inside library expressions** — a model may
-only use ordinal-style access against a global set: the bare set-id for the current position
-(`X{fuel}`), a relative shift (`X{fuel+1}`), or an explicit integer position (`X{0}`). This holds
-regardless of `kind` — `enumerated` still means "named, ordered elements" once `system.yml` resolves
-it, it just means library expressions can only reach those elements by position, never by name. This
-is not actually specific to global sets: since **local** sets now follow the identical rule (concrete
-contents always assigned in `system.yml`, never given in the model — see [Declaring a local
-(model-level) set](#declaring-a-local-model-level-set) above), named-element access is never valid
-against *any* set inside library expressions, local or global.
-
-**Recommended practice** (a `system.yml`-level concern now, since that's the only place a global set's
-concrete contents ever exist): instantiate each study's global sets as *universal* — the superset of
-every element that could ever be relevant across the whole system (e.g. `elements: [gas, coal, oil,
-biomass, hydrogen]` even if a given generator only burns two of them) — and express per-component
-variation through the *data* (e.g. a capacity/bound of `0` for unused elements) rather than through
-differing set membership. This keeps the set's dimension uniform across every component, exactly like
-time and scenario already are, which is what makes cross-component aggregation (`sum_connections`,
-binding constraints — see [Port fields and custom sets](#port-fields-and-custom-sets)) well-defined
-without any extra runtime validation.
-
-No locally-declared identifier in a model — not just a local set, but also a parameter, variable,
-port, constraint, or any other model-level `id` — may collide with a global set's `id` visible in the
-same library, since both are resolved through the same bare-identifier / `indexed-by` lookup; see
-[Rules for id naming](file-structure/library.md#rules-for-id-naming) for the complete rule.
-
-### Marking a parameter or variable as set-indexed
-
-A new `indexed-by` field, alongside the existing `time-dependent` / `scenario-dependent` booleans,
-declares that a parameter or variable carries one or more custom-set dimensions. It resolves against
-the model's own local sets, plus every global set declared in the library:
-
-```yaml
-parameters:
-  - id: segment_capacity
-    indexed-by: segment
-    time-dependent: false
-    scenario-dependent: false
-variables:
-  - id: segment_level
-    indexed-by: segment
-    lower-bound: 0
-    upper-bound: segment_capacity{segment}
-    variable-type: continuous
-```
-
-`indexed-by` also accepts a list (`indexed-by: [segment, fuel]`) for a parameter or variable indexed
-by more than one custom set at once — see [Multiple indexing sets](#multiple-indexing-sets) below.
-
 ### Port fields and custom sets
 
-A port-type field may declare `indexed-by` directly, exactly like a parameter or variable — including
-a list for a field indexed by more than one set (`indexed-by: [fuel, region]`, using the same
-comma-list `{...}` syntax as [Multiple indexing sets](#multiple-indexing-sets)) — but it may only
-reference **global** sets, never a local one, since port types are declared independently of any
-model and have no visibility into a model's local sets:
-
-```yaml
-port-types:
-  - id: multi_fuel_port
-    fields:
-      - id: flow
-        indexed-by: fuel
-```
-
-A [`port-field-definition`](file-structure/library.md#port-field-definition)'s expression must produce
-a value whose inferred indexing matches the field's declared `indexed-by` exactly — the same kind of
-consistency check already required to keep a variable's declared time/scenario structure consistent
-with its defining expression, extended to this new dimension:
+Exactly like time/scenario dependence for ports (see [the base Ports
+section](#ports) above), a port-type field declares nothing new for custom sets: a field's custom-set
+indexing is inferred purely from how connected models define it — e.g. if `p_generation` is
+`indexed-by: fuel`, then
 
 ```yaml
 port-field-definitions:
   - port: injection_port
     field: flow
-    definition: p_generation{fuel}   # must be `fuel`-indexed to match flow's declared indexed-by
+    definition: p_generation{fuel}
 ```
 
-**Multidimensional port fields** — a field's `indexed-by` list can name more than one set, exactly
-like a parameter or variable's can (see [Multiple indexing sets](#multiple-indexing-sets)):
+infers that `flow` is fuel-indexed too.
 
-```yaml
-port-types:
-  - id: multi_fuel_multi_region_port
-    fields:
-      - id: flow
-        indexed-by: [fuel, region]
+The only restriction on this inference: **a `port-field-definition`'s expression may only be indexed by
+global sets, never a local one** — local sets are per-component/ragged (see [Why the distinction
+matters](#why-the-distinction-matters) above), so letting one cross a port would silently break
+aggregation the moment two connected components' local sets disagree in size or content. This is
+checked on every model's `definition` on its own.
 
-port-field-definitions:
-  - port: injection_port
-    field: flow
-    definition: p_generation{fuel, region}   # must match flow's declared indexed-by exactly
-```
+Different models connecting to the same port type do **not** need to agree on which global set(s) they
+use for the same field — one model's definition can be `fuel`-indexed, another's `region`-indexed,
+another's unindexed, all for the same field of the same port type. `sum_connections` and any binding
+constraint combining them unfolds over the **union** of every global set involved, exactly like today's
+[cross-product unfolding](#implicit-unfolding) of mixed time/scenario-dependent terms: each model's
+contribution is broadcast — replicated — across whichever of those dimensions its own definition
+doesn't carry, then summed element-wise. This is the same mechanism that already combines a purely
+time-dependent term with a purely scenario-dependent one; custom sets just add further dimensions to
+the same cross-product.
 
-Because a port field may only ever reference global sets in the first place, this holds dimension by
-dimension: **every** set in a multidimensional port field's `indexed-by` must be global — there is no
-partial or mixed case where some dimensions are global and others local.
+A definition indexed by more than one set at once (`p_generation{fuel, region}`) is simply inferred as
+such, exactly as for a parameter or variable (see [Multiple indexing sets](#multiple-indexing-sets)) —
+the global-only restriction then applies dimension by dimension (every set in the tuple must be global,
+never a mix).
 
-Because a port field's `indexed-by` can only name a global set, and every component connecting through
-that port type necessarily shares that exact global set, [`sum_connections`](#port-operator) and any
-[binding constraint](file-structure/library.md#binding-constraints) built on top of it are well-defined
-by construction — no additional runtime guard is needed beyond this schema-level restriction.
-
-**Escape hatch, and its limit:** if a model genuinely needs a port-facing global set *and* a
-related-but-different, per-component-flexible local set, `sum_over` only helps in the degenerate case
-where the port field itself ends up **unindexed** — i.e. the field is a plain aggregate total, not
-broken down by element (`sum_over(local_set, internal_var)` fully collapses `local_set` to a scalar,
-per the [dimension-selectivity rule](#aggregating-over-a-custom-set) below). It **cannot** produce a
-value still indexed by the global set (e.g. `flow{fuel}`) out of a differently-shaped local set —
-`sum_over` reduces a dimension to a scalar, it does not remap one set's index space onto another's.
-If the port field must genuinely stay broken down by global-set element, and the model's internal
-detail lives on a different, differently-shaped local set, **this proposal has no solution**: it would
-require a true set-to-set mapping/index-alignment primitive, which does not exist here and would be
-future work.
+**Escape hatch, and its limit:** `sum_over` can bridge a port-facing global set and a related local set
+only in the degenerate case where the port field ends up **unindexed** — `sum_over(local_set,
+internal_var)` fully collapses the local set to a scalar (see [Aggregating over a custom
+set](#aggregating-over-a-custom-set) below). It cannot remap a local set's index space onto a global
+set's: if the port field must stay broken down by global-set element while the model's internal detail
+lives on a differently-shaped local set, **this proposal has no solution** — that would require a true
+set-to-set mapping primitive, left as future work.
 
 ### Indexing expressions
 
 | Form | Meaning | Time analogue |
 |---|---|---|
 | `X{segment}` | current element (implicit within an unfolded/aggregated context) | `X[t]` |
-| `X{2}` | explicit element at position 2 (ordinal sets, 0-based) | `X[5]` |
-| `X{segment+1}` / `X{segment-1}` | relative shift by position (ordinal sets only) | `X[t+1]` / `X[t-1]` |
+| `X{2}` | explicit element at position 2 (0-based) | `X[5]` |
+| `X{segment+1}` / `X{segment-1}` | relative shift by position | `X[t+1]` / `X[t-1]` |
 | `(expr){segment}` | index an arbitrary parenthesized **expression**, not just a bare identifier | `(expr)[t+1]` |
 | `X{segment}[t+1]` | compose set- and time-indexing on the same term | — |
 
@@ -436,9 +298,50 @@ Because a set's `id` is an ordinary identifier — not a reserved keyword the wa
 arithmetic precedence already parses `segment+1`, `2*segment - 1`, etc. correctly; no dedicated
 "shift" grammar (like time's) is required for custom sets.
 
-**Note:** there is deliberately no "bare named-element" form (e.g. `X{gas}`) in this table — a set's
-concrete elements are never known at library-authoring time (see [Declaring a global (library-level)
-set](#declaring-a-global-library-level-set) above), so named access is not part of this syntax at all.
+**Note:** there is deliberately no "bare named-element" form (e.g. `X{gas}`) in this table. A set's
+`elements` are never known at library-authoring time — only once `system.yml`
+[instantiates them](file-structure/system.md#global-sets) (for a global set) or per component (for a
+local one) — so a model may only ever access a set positionally: the bare set-id for the current
+position (`X{fuel}`), a relative shift (`X{fuel+1}`), or an explicit integer position (`X{0}`). This
+holds no matter how `system.yml` ends up instantiating the set's elements — a name list still only
+reaches its elements by position from inside the library, never by name. This applies identically to
+local and global sets.
+
+**Position and label are not the same thing once a range doesn't start at 0.** With a 0-based range
+(`0..4`), position and value happen to coincide — but nothing requires a range to start there. Given
+`elements: 2020..2024` (e.g. a set of vintage years) in `system.yml`, `X{0}` still means "the first
+declared element" — here, the element whose value is `2020` — not "the element whose value is 0."
+Positional indexing (`X{segment}`, `X{2}`, `X{segment+1}`) always addresses *position within the
+declared list*, never the element's value, whether that list came from an explicit list or a range.
+
+**On meaningfulness, not validity:** every form above is well-defined for any set — `system.yml`
+always resolves a set to an ordered list, whether it came from a range or a name list, and `{...}`
+only ever operates on that order positionally. But `X{segment+1}`-style relative shift only makes
+*modeling* sense when the set's declared order itself carries meaning — price tiers, vintage years,
+dispatch priority. For a set whose order is incidental (e.g. `fuel: [gas, coal, oil]`, listed in no
+particular order), `X{fuel+1}` is syntactically legal but likely a modeling mistake, not a real "next
+fuel" relationship. Unlike time, whose order is always chronological, GEMS doesn't distinguish the two
+cases in the schema — it's on the library author to only rely on relative shift where the declared
+order is deliberate.
+
+**Getting data associated with each element:** there is no way to use a set's index position as a bare
+arithmetic value (e.g. `segment * price_step`, using `segment` as a raw number) — only the forms above
+are supported. If a model needs per-element data — a price step per segment, a conversion factor per
+fuel — declare an ordinary parameter `indexed-by` that set and supply its values via the [set-indexed
+data series](file-structure/data-series.md#set-indexed-series) format, the same way a time-dependent
+parameter's values come from a time series rather than from any implicit function of `t`:
+
+```yaml
+parameters:
+  - id: segment_price_step
+    indexed-by: segment
+    time-dependent: false
+    scenario-dependent: false
+
+constraints:
+  - id: segment_marginal_cost
+    expression: segment_price{segment} = base_price + segment_price_step{segment}
+```
 
 ### Aggregating over a custom set
 
@@ -456,6 +359,15 @@ constraints:
 carries — time, scenario, or another custom set — is preserved, exactly as `sum(X)` collapses time
 alone and leaves scenario untouched.
 
+**Getting a set's size:** there is no dedicated operator for this — `t`'s own count (`T`) isn't
+exposed to expressions either, so a set doesn't get special treatment here. `sum_over(set_id, 1)`
+already gives it for free: summing the constant `1` once per element yields the set's cardinality,
+with no new syntax needed.
+
+```yaml
+expression: average_level = sum_over(segment, segment_level) / sum_over(segment, 1)
+```
+
 ### Multiple indexing sets
 
 A parameter or variable can be indexed by more than one custom set. Indices are comma-separated
@@ -464,10 +376,7 @@ inside a single pair of braces, in the same order as declared in `indexed-by`:
 ```yaml
 sets:
   - id: segment
-    kind: ordinal
-    cardinality: segment_count
   - id: fuel
-    kind: enumerated   # elements supplied per component in system.yml
 
 parameters:
   - id: segment_fuel_cost
@@ -485,9 +394,7 @@ parameters:
 Both `segment` and `fuel` here are **local** sets, but the same multi-set syntax applies identically
 to global sets, or a mix of the two — `indexed-by` doesn't care about scope, only about which sets are
 named and in what order. As always, every index in every slot is position-based only — `X{2, 1}`, not
-`X{2, gas}` — since neither set's concrete elements are known at library-authoring time (see
-[Declaring a local (model-level) set](#declaring-a-local-model-level-set) and [Declaring a global
-(library-level) set](#declaring-a-global-library-level-set)).
+`X{2, gas}` — see [Indexing expressions](#indexing-expressions) above for why.
 
 Aggregation stays single-set per call and nests for multi-set reduction, rather than introducing a
 second aggregation form:
@@ -508,37 +415,12 @@ all of them, generalizing the time+scenario dual-unfolding rule the base doc alr
 term that is both time- and scenario-dependent already unfolds per `(t, s)` pair today; a term that is
 also `segment`-indexed unfolds per `(t, s, segment)` triple, and so on for any further set).
 
-### Indexing a constraint explicitly, and referencing the index value itself
-
-Implicit unfolding only fires when the constraint contains a term that is itself `indexed-by` the
-set. To unfold a constraint over a set even when none of its terms are set-indexed — typically
-because the constraint only needs the *index value* itself, not a subscript into anything — add an
-explicit `indexed-by` field on the constraint (this field applies identically to
-`binding-constraints`, `objective-contributions`, and `extra-outputs`):
-
-```yaml
-constraints:
-  - id: segment_marginal_cost
-    indexed-by: segment
-    expression: segment_price{segment} = base_price + segment * price_step
-```
-
-Used bare, outside `{ }`, a set's own `id` evaluates to the current element's 0-based integer
-position within whichever set-indexed context it is unfolding in — e.g. bare `segment` above is a
-plain number (0, 1, 2, …), not a subscript operator. This holds uniformly for both ordinal and
-enumerated sets, since even an enumerated set has a well-defined order once `system.yml` resolves it
-(`fuel` bare = 0 for `gas`, 1 for `coal`, 2 for `oil`, given a resolved `elements: [gas, coal, oil]`).
-
-This is exactly why the naming rules forbid a set's `id` from colliding with a parameter/variable `id`
-or the reserved literal `t` (a local set), or with any locally-declared identifier at all (a global
-set) — see [Rules for id naming](file-structure/library.md#rules-for-id-naming) for the complete rule
-— otherwise a bare reference to that name would be ambiguous between "current index position", a
-parameter/variable lookup, or the built-in time index.
-
-This also resolves the case of a constraint that carries *both* an implicit set dimension (inferred
-from one of its own terms) and an explicit `indexed-by` naming a *different* set: per
-[Cross-product unfolding](#implicit-unfolding) above, the constraint simply unfolds over the
-union/cross-product of both dimensions, exactly as it would for any other combination of dimensions.
+Unfolding over a custom set is driven entirely by set-indexed parameter/variable terms appearing in the
+expression, exactly like time/scenario unfolding today — there is no mechanism to force-unfold a
+constraint over a set with no set-indexed term in it. This follows from `indexed-by` [existing only on
+parameters and variables](file-structure/library.md#sets) (see [Indexing
+expressions](#indexing-expressions) above for the replacement pattern when a constraint needs data
+associated with each element).
 
 ### Collision check
 

--- a/doc/user-guide/outputs/simulation-table.md
+++ b/doc/user-guide/outputs/simulation-table.md
@@ -35,8 +35,8 @@ from the solved [optimization problem](./optimization-problem-files.md). It esse
 
 | Column | Description |
 |------|--------------------------|
-|`set_id`| Blank for outputs with no [custom-set](../file-structure/library.md#sets) dimension. Otherwise, the `id` of the set this output is indexed by — a local (model-level) or [global (library-level)](../file-structure/library.md#library-level-sets) set, encoded identically either way. For an output indexed by more than one set (e.g. `X{segment, fuel}`), a comma-joined list in declaration order, e.g. `segment,fuel`.|
-|`set_index`| Blank when `set_id` is blank. Otherwise, the element of that set for this row — an integer position for ordinal sets, or the element name for enumerated sets. For a multi-set output, a comma-joined list in the same order as `set_id`, e.g. `1,gas`.|
+|`set_id`| Blank for outputs with no [custom-set](../file-structure/library.md#sets) dimension. Otherwise, the `id` of the set this output is indexed by — a local (model-level) or [global (library-level)](../file-structure/library.md#library-level-sets) set, encoded identically either way. For an output indexed by more than one set (e.g. `X{segment, fuel}`), a pipe-joined list in declaration order, e.g. `segment\|fuel`.|
+|`set_index`| Blank when `set_id` is blank. Otherwise, the element value for that row, exactly as instantiated in `system.yml` — an integer position for a range-instantiated set, or the element name for a name-instantiated set. For a multi-set output, a pipe-joined list in the same order as `set_id`, e.g. `1\|gas`.|
 
 # Simulation Table exported by [Antares Simulator](../../overview/gems-interpreters/antares-simulator.md)
 
@@ -56,5 +56,13 @@ implemented, a set-indexed output would add the two proposed columns, e.g.:
 ```csv
 block,component,output,absolute_time_index,block_time_index,scenario_index,set_id,set_index,value,basis_status
 1,STORAGE,segment_level,1,1,1,segment,1,120.0,Basic
+```
+
+An output indexed by more than one set pipe-joins both `set_id` and `set_index`, e.g. a
+`segment_fuel_cost` output indexed by `{segment, fuel}`:
+
+```csv
+block,component,output,absolute_time_index,block_time_index,scenario_index,set_id,set_index,value,basis_status
+1,GENERATOR,segment_fuel_cost,1,1,1,segment|fuel,1|gas,55.0,Basic
 ```
 


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- DOC-01 | DOC-02 | LT-01 | LT-02 | LT-03 | N/A -->

**Process:**

## Description

Reworks the **Custom Sets and Indexing** design proposal across the GEMS documentation, along two axes:

- **Simplifies the proposed design**: merges the two set kinds (`ordinal`/`enumerated`) into a single shape — `elements` are always an ordered list (explicit, or via the new `S..E` range shorthand), and the `kind`/`cardinality` fields are dropped. `indexed-by` now exists only on `parameters`/`variables` (no longer on `constraints`, `binding-constraints`, `objective-contributions`, `extra-outputs`): unfolding over a custom set is now driven purely by a set-indexed term appearing in the expression, exactly like time and scenario. Port fields no longer declare `indexed-by` themselves — their custom-set indexing is now **inferred** from connected models' definitions, the same inference already used for time/scenario dependence.
- **Deduplicates the documentation**: each rule of the proposal is now stated in full exactly once, in whichever file is the most relevant home for it (`mathematical-syntax.md` for expression semantics, `library.md`/`system.md` for schema), with every other file pointing to that single location instead of restating it. Several internal links that had gone stale across earlier rewrites were also fixed.

## Impact Analysis

Documentation only — no model library, code, or study is changed.

Affected files:
- `doc/user-guide/mathematical-syntax.md`
- `doc/user-guide/file-structure/library.md`
- `doc/user-guide/file-structure/system.md`
- `doc/user-guide/file-structure/data-series.md`
- `doc/user-guide/outputs/simulation-table.md`

No breaking changes: the entire **Custom Sets and Indexing** feature remains marked "Design proposal — not yet implemented" and isn't implemented in GemsPy — no existing study or library can use this syntax today.

## Checklist

- [ ] E2E tests pass (or confirmed not affected)
- [ ] Library version bumped if library changed (`library.version` in `libraries/<library>.yml`)
- [ ] Changelog entry added if library changed (`libraries/CHANGELOG-<library>.md`)
- [ ] Release notes entry added if language-level change (`doc/0_Home/4_release_notes.md`)
- [ ] Compatibility matrix updated if applicable (`COMPATIBILITY.md`)
- [ ] Documentation updated or confirmed up to date
- [ ] `AGENTS.md` reviewed for impact and updated if needed
