### PR TITLE
Add Cloudflare Pages production deployment workflow

### DIFF
--- a/.github/workflows/promote-release-to-production.yml
+++ b/.github/workflows/promote-release-to-production.yml
@@ -1,0 +1,36 @@
+name: Promote Release to Production
+
+# Cloudflare Pages ties its "Production" deployment (the principal/custom
+# domain) to a single Git branch and rebuilds it on every push to that
+# branch. To make the principal URL always reflect the latest GitHub
+# Release instead of the latest commit on `main`, this workflow fast-forwards
+# a dedicated `production` branch to the released tag whenever a release is
+# published. Point the Cloudflare Pages project's "Production branch"
+# setting to `production` (not `main`) for this to take effect.
+#
+# Branch/PR preview URLs are unaffected: Cloudflare Pages already deploys a
+# preview build (with its own URL) for every other branch automatically.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: Fast-forward production branch to released tag
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Update production branch
+        run: |
+          git checkout -B production "${{ github.event.release.tag_name }}"
+          git push --force-with-lease origin production

--- a/doc/support/dev-guidelines.md
+++ b/doc/support/dev-guidelines.md
@@ -376,6 +376,20 @@ The `pypsa_models.yml` and `antares_legacy_models.yml` libraries in GEMS reposit
 
 ---
 
+### Cloudflare Pages Deployment (GEMS)
+
+The GEMS documentation site is additionally deployed to Cloudflare Pages (in parallel with the canonical ReadTheDocs hosting). Cloudflare Pages ties its **Production** deployment — the one served on the project's principal/custom domain — to a single Git branch, and rebuilds it on every push to that branch. Every other branch (including PR branches) automatically gets its own **preview** deployment at `https://<branch>.<project>.pages.dev`.
+
+To make the principal domain always show the latest GitHub Release rather than the latest commit on `main`:
+
+1. In the Cloudflare Pages dashboard, set the project's **Production branch** to `production` (not `main`).
+2. The `promote-release-to-production` workflow (`.github/workflows/promote-release-to-production.yml`) fast-forwards the `production` branch to the released tag whenever a GitHub Release is published on `main`. Cloudflare then rebuilds the principal domain from that branch automatically.
+3. No manual step is needed after publishing a release — `production` only moves when step 4 of the GEMS release process (§8.3) is completed.
+
+PR/branch previews need no repository-side change: Cloudflare Pages already builds one per branch. To expose them under a custom domain instead of the default `*.pages.dev` alias, configure a wildcard **Preview URL custom domain** (e.g. `*.preview.<your-domain>`) for the project in the Cloudflare Pages dashboard → Custom domains.
+
+---
+
 ### Cross-Repository Notifications
 
 When a model library is updated in a converter, an issue is automatically created in the **GEMS** repository to prompt synchronisation of the shared library YAML.


### PR DESCRIPTION
## Process ID

**Process:** DOC-02

## Description

This PR adds automation to keep the GEMS documentation site's principal domain synchronized with GitHub Releases when deployed to Cloudflare Pages.

**Changes:**
1. **New workflow** (`.github/workflows/promote-release-to-production.yml`): Automatically fast-forwards a dedicated `production` Git branch to the released tag whenever a GitHub Release is published. This allows Cloudflare Pages to rebuild the principal domain from the latest release rather than the latest commit on `main`.

2. **Updated developer guidelines** (`doc/support/dev-guidelines.md`): Added a new "Cloudflare Pages Deployment (GEMS)" section documenting:
   - How the production branch ties to Cloudflare Pages' principal domain
   - Configuration steps (setting production branch to `production` in Cloudflare dashboard)
   - How the workflow integrates with the release process
   - How PR/branch previews work automatically

## Impact Analysis

- **Documentation only**: No changes to libraries, models, or studies
- **Deployment infrastructure**: Adds a new automated workflow that runs on release publication
- **No breaking changes**: The workflow is additive and requires explicit Cloudflare dashboard configuration to take effect

## Checklist

- [x] Documentation updated (`doc/support/dev-guidelines.md`)
- [x] Workflow configuration added and documented
- [ ] E2E tests pass (N/A — infrastructure/documentation change)
- [ ] Library version bump (N/A — no library changes)
- [ ] Changelog entry (N/A — no library changes)
- [ ] Release notes entry (N/A — internal process documentation)
- [ ] Compatibility matrix (N/A — no compatibility impact)
- [ ] AGENTS.md review (N/A — no agent-relevant changes)

https://claude.ai/code/session_012TgqK3sDoya8RzA6WvtHgA