### PR TITLE
Docs/Feature tiles on the Features and Use Cases page

### DIFF
--- a/doc/home/use-cases.md
+++ b/doc/home/use-cases.md
@@ -18,7 +18,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    Define abstract models once in a library, instantiate them as components, and connect them through typed ports. Balance equations are written once inside a model and resolved over the whole graph, so a system is assembled rather than hard-coded.
+    Define abstract models once in a library, instantiate them as components, and connect them through typed ports. 
 
     `Language`
 
@@ -28,7 +28,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    Write equations as text close to the mathematics — arithmetic and comparison operators, `min`/`max`/`floor`/`ceil`/`abs`/`round`, powers — with linearity checked by the interpreter so the resulting problem stays solvable.
+    Write equations as text close to the mathematics — arithmetic and comparison operators, `min`/`max`/`floor`/`ceil`/`abs`/`round`, powers — with linearity checked by the interpreters.
 
     `Language`
 
@@ -44,11 +44,11 @@ Each tile links to the reference page describing the feature in detail.
 
     [:octicons-arrow-right-24: Port types](../user-guide/file-structure/library.md#port-types)
 
--   :material-clock-outline:{ .lg .middle } **Time built into the language**
+-   :material-clock-outline:{ .lg .middle } **Time as a native dimension**
 
     ---
 
-    No index sets to declare: refer to the current time step, shift it forward or backward for storage and ramping dynamics, and aggregate over the full horizon or a moving window. Shifted indices wrap around to keep the horizon periodic.
+    No index sets to declare for time: refer to the current time step, shift it forward or backward for storage and ramping dynamics, and aggregate over the full horizon or a moving window. 
 
     `Language`
 
@@ -58,7 +58,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    Parameters and variables can vary by scenario alongside time, and the expectation operator aggregates across the scenario dimension — the basis for Monte Carlo studies and for coupling scenarios in stochastic formulations.
+    Parameters and variables can vary by scenario alongside time, and the expectation operator aggregates across the scenario dimension: the basis for Monte Carlo studies and for coupling scenarios through 2-stage stochastic formulations.
 
     `Language`
 
@@ -78,7 +78,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    Attach arbitrary key/value properties to components — carrier, technology, operator — either declared by the model or added freely. They carry no mathematical meaning and are available downstream for filtering, aggregation and visualisation.
+    Attach arbitrary key/value properties to components (e.g. carrier, technology, operator) either declared by the model or added freely. They are available downstream for filtering, aggregation and visualisation.
 
     `Data`
 
@@ -98,7 +98,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    Variables can be continuous, integer or binary, with bounds given by parameters or expressions. Discrete operational decisions — unit commitment, start-up and shut-down logic — are expressed directly in the model.
+    Variables can be continuous, integer or binary, with bounds given by parameters or expressions. Discrete operational decisions (e.g. unit commitment, start-up and shut-down logic) are expressed directly in the model.
 
     `Solving`
 
@@ -118,7 +118,7 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    A long horizon can be solved in successive blocks rather than as one monolithic problem, the basis for rolling-horizon resolution. Every result carries the block it came from. Block workflows are configured outside the system file and their coverage differs between interpreters.
+    A long horizon can be solved in successive blocks rather than as one monolithic problem, the basis for rolling-horizon resolution. Every result carries the block it came from. 
 
     `Solving`
 
@@ -128,21 +128,12 @@ Each tile links to the reference page describing the feature in detail.
 
     ---
 
-    One flat table holds the value of every variable, constraint, port field and extra output, identified by component, time step and scenario. It includes duals and reduced costs for marginal prices, and user-defined extra outputs evaluated after the solve — where comparisons become 0/1 flags, for indicators such as loss of load.
+    One flat table holds the value of every variable, constraint, port field and extra output, identified by component, time step and scenario. It includes duals and reduced costs for marginal prices, and user-defined extra outputs evaluated after the solve.
 
     `Outputs`
 
     [:octicons-arrow-right-24: Simulation table](../user-guide/outputs/simulation-table.md)
 
--   :material-file-export-outline:{ .lg .middle } **Inspect the problem you actually solve**
-
-    ---
-
-    The fully assembled linear or mixed-integer problem can be exported in the standard MPS format. Nothing about the formulation stays hidden inside the tool, which makes results verifiable, debuggable and comparable across solvers.
-
-    `Outputs`
-
-    [:octicons-arrow-right-24: Optimization problem files](../user-guide/outputs/optimization-problem-files.md)
 
 </div>
 

--- a/doc/home/use-cases.md
+++ b/doc/home/use-cases.md
@@ -1,8 +1,152 @@
 ---
-description: Discover the main use cases of GEMS - adequacy assessment, economic dispatch, energy system planning, multi-energy modelling, and hybrid integration with Antares Simulator.
+description: What the GEMS language supports today - graph-based modelling, native time and scenario dimensions, LP/MIP/MILP and two-stage stochastic optimisation, granular outputs - and the studies it was designed for.
 ---
 
-# Use Cases
+# Features and Use Cases
+
+This page summarises what the GEMS language and format support **today**, and the kinds of studies they were designed for.
+
+For what is being worked on next, see the [Roadmap](roadmap.md). For the history of changes, see the [Release Notes](release-notes.md).
+
+## Features
+
+Each tile links to the reference page describing the feature in detail.
+
+<div class="grid cards" markdown>
+
+-   :material-graph-outline:{ .lg .middle } **Systems as graphs of connected components**
+
+    ---
+
+    Define abstract models once in a library, instantiate them as components, and connect them through typed ports. Balance equations are written once inside a model and resolved over the whole graph, so a system is assembled rather than hard-coded.
+
+    `Language`
+
+    [:octicons-arrow-right-24: Library file](../user-guide/file-structure/library.md)
+
+-   :material-function-variant:{ .lg .middle } **Readable, math-like expression syntax**
+
+    ---
+
+    Write equations as text close to the mathematics — arithmetic and comparison operators, `min`/`max`/`floor`/`ceil`/`abs`/`round`, powers — with linearity checked by the interpreter so the resulting problem stays solvable.
+
+    `Language`
+
+    [:octicons-arrow-right-24: GEMS syntax](../user-guide/syntax.md)
+
+-   :material-transit-connection-variant:{ .lg .middle } **Multi-energy and sector coupling**
+
+    ---
+
+    Port types are defined by the user, not fixed by the tool. A single component can expose several of them at once — power flow, cumulative energy, emissions — making integrated multi-energy and multi-sector systems a natural fit.
+
+    `Language`
+
+    [:octicons-arrow-right-24: Port types](../user-guide/file-structure/library.md#port-types)
+
+-   :material-clock-outline:{ .lg .middle } **Time built into the language**
+
+    ---
+
+    No index sets to declare: refer to the current time step, shift it forward or backward for storage and ramping dynamics, and aggregate over the full horizon or a moving window. Shifted indices wrap around to keep the horizon periodic.
+
+    `Language`
+
+    [:octicons-arrow-right-24: Time operators and indexing](../user-guide/syntax.md#time-operators-and-indexing)
+
+-   :material-dice-multiple-outline:{ .lg .middle } **Uncertainty as a native dimension**
+
+    ---
+
+    Parameters and variables can vary by scenario alongside time, and the expectation operator aggregates across the scenario dimension — the basis for Monte Carlo studies and for coupling scenarios in stochastic formulations.
+
+    `Language`
+
+    [:octicons-arrow-right-24: Scenario operator](../user-guide/syntax.md#scenario-operator)
+
+-   :material-file-table-outline:{ .lg .middle } **Scenario building from data series**
+
+    ---
+
+    Time-dependent, scenario-dependent and time × scenario data live in plain CSV files. The scenario builder maps each Monte Carlo scenario to a data series column per scenario group, so the same system can be replayed against different datasets.
+
+    `Data`
+
+    [:octicons-arrow-right-24: Scenario builder](../user-guide/file-structure/scenario-builder.md)
+
+-   :material-tag-outline:{ .lg .middle } **Component properties and metadata**
+
+    ---
+
+    Attach arbitrary key/value properties to components — carrier, technology, operator — either declared by the model or added freely. They carry no mathematical meaning and are available downstream for filtering, aggregation and visualisation.
+
+    `Data`
+
+    [:octicons-arrow-right-24: Component properties](../user-guide/file-structure/system.md#properties)
+
+-   :material-swap-horizontal:{ .lg .middle } **Solver-agnostic by design**
+
+    ---
+
+    Model equations live in YAML files, never in software code, and are interpreted at run time. The optimisation solver is a configuration choice — `sirius`, `scip`, `xpress`, `gurobi`, `highs`, `coin`, `glpk` or `pdlp` — with solver-specific options passed through.
+
+    `Solving`
+
+    [:octicons-arrow-right-24: Solver configuration](../user-guide/file-structure/solver-optimization.md)
+
+-   :material-vector-polyline:{ .lg .middle } **LP, MIP and MILP problems**
+
+    ---
+
+    Variables can be continuous, integer or binary, with bounds given by parameters or expressions. Discrete operational decisions — unit commitment, start-up and shut-down logic — are expressed directly in the model.
+
+    `Solving`
+
+    [:octicons-arrow-right-24: Variables](../user-guide/file-structure/library.md#variables)
+
+-   :material-trending-up:{ .lg .middle } **Investment and two-stage stochastic optimisation**
+
+    ---
+
+    A model can declare several objective contributions belonging to different optimisation stages, separating investment (here-and-now) from operation (recourse). This is what makes capacity-expansion studies and Benders-style decomposition expressible in the language.
+
+    `Solving`
+
+    [:octicons-arrow-right-24: Objective contributions](../user-guide/file-structure/library.md#objective-contribution)
+
+-   :material-view-week-outline:{ .lg .middle } **Block decomposition of the horizon**
+
+    ---
+
+    A long horizon can be solved in successive blocks rather than as one monolithic problem, the basis for rolling-horizon resolution. Every result carries the block it came from. Block workflows are configured outside the system file and their coverage differs between interpreters.
+
+    `Solving`
+
+    [:octicons-arrow-right-24: The `block` column](../user-guide/outputs/simulation-table.md)
+
+-   :material-table-large:{ .lg .middle } **Full, granular results**
+
+    ---
+
+    One flat table holds the value of every variable, constraint, port field and extra output, identified by component, time step and scenario. It includes duals and reduced costs for marginal prices, and user-defined extra outputs evaluated after the solve — where comparisons become 0/1 flags, for indicators such as loss of load.
+
+    `Outputs`
+
+    [:octicons-arrow-right-24: Simulation table](../user-guide/outputs/simulation-table.md)
+
+-   :material-file-export-outline:{ .lg .middle } **Inspect the problem you actually solve**
+
+    ---
+
+    The fully assembled linear or mixed-integer problem can be exported in the standard MPS format. Nothing about the formulation stays hidden inside the tool, which makes results verifiable, debuggable and comparable across solvers.
+
+    `Outputs`
+
+    [:octicons-arrow-right-24: Optimization problem files](../user-guide/outputs/optimization-problem-files.md)
+
+</div>
+
+## Use Cases
 
 GEMS modelling language was primarily designed for the following purposes:
 

--- a/doc/home/use-cases.md
+++ b/doc/home/use-cases.md
@@ -34,15 +34,16 @@ Each tile links to the reference page describing the feature in detail.
 
     [:octicons-arrow-right-24: GEMS syntax](../user-guide/syntax.md)
 
--   :material-transit-connection-variant:{ .lg .middle } **Multi-energy and sector coupling**
+-   :material-vector-polyline:{ .lg .middle } **LP, MIP and MILP problems**
 
     ---
 
-    Port types are defined by the user, not fixed by the tool. A single component can expose several of them at once — power flow, cumulative energy, emissions — making integrated multi-energy and multi-sector systems a natural fit.
+    Variables can be continuous, integer or binary, with bounds given by parameters or expressions. Discrete operational decisions (e.g. unit commitment, start-up and shut-down logic) are expressed directly in the model.
 
-    `Language`
+    `Solving`
 
-    [:octicons-arrow-right-24: Port types](../user-guide/file-structure/library.md#port-types)
+    [:octicons-arrow-right-24: Variables](../user-guide/file-structure/library.md#variables)
+
 
 -   :material-clock-outline:{ .lg .middle } **Time as a native dimension**
 
@@ -64,45 +65,6 @@ Each tile links to the reference page describing the feature in detail.
 
     [:octicons-arrow-right-24: Scenario operator](../user-guide/syntax.md#scenario-operator)
 
--   :material-file-table-outline:{ .lg .middle } **Scenario building from data series**
-
-    ---
-
-    Time-dependent, scenario-dependent and time × scenario data live in plain CSV files. The scenario builder maps each Monte Carlo scenario to a data series column per scenario group, so the same system can be replayed against different datasets.
-
-    `Data`
-
-    [:octicons-arrow-right-24: Scenario builder](../user-guide/file-structure/scenario-builder.md)
-
--   :material-tag-outline:{ .lg .middle } **Component properties and metadata**
-
-    ---
-
-    Attach arbitrary key/value properties to components (e.g. carrier, technology, operator) either declared by the model or added freely. They are available downstream for filtering, aggregation and visualisation.
-
-    `Data`
-
-    [:octicons-arrow-right-24: Component properties](../user-guide/file-structure/system.md#properties)
-
--   :material-swap-horizontal:{ .lg .middle } **Solver-agnostic by design**
-
-    ---
-
-    Model equations live in YAML files, never in software code, and are interpreted at run time. The optimisation solver is a configuration choice — `sirius`, `scip`, `xpress`, `gurobi`, `highs`, `coin`, `glpk` or `pdlp` — with solver-specific options passed through.
-
-    `Solving`
-
-    [:octicons-arrow-right-24: Solver configuration](../user-guide/file-structure/solver-optimization.md)
-
--   :material-vector-polyline:{ .lg .middle } **LP, MIP and MILP problems**
-
-    ---
-
-    Variables can be continuous, integer or binary, with bounds given by parameters or expressions. Discrete operational decisions (e.g. unit commitment, start-up and shut-down logic) are expressed directly in the model.
-
-    `Solving`
-
-    [:octicons-arrow-right-24: Variables](../user-guide/file-structure/library.md#variables)
 
 -   :material-trending-up:{ .lg .middle } **Investment and two-stage stochastic optimisation**
 
@@ -123,6 +85,39 @@ Each tile links to the reference page describing the feature in detail.
     `Solving`
 
     [:octicons-arrow-right-24: The `block` column](../user-guide/outputs/simulation-table.md)
+    
+-   :material-file-table-outline:{ .lg .middle } **Scenario building from data series**
+
+    ---
+
+    Time-dependent, scenario-dependent and time × scenario data live in plain CSV files. The scenario builder maps each Monte Carlo scenario to a data series column per scenario group, so the same system can be replayed against different datasets.
+
+    `Data`
+
+    [:octicons-arrow-right-24: Scenario builder](../user-guide/file-structure/scenario-builder.md)
+-   :material-tag-outline:{ .lg .middle } **Component properties and metadata**
+
+    ---
+
+    Attach arbitrary key/value properties to components (e.g. carrier, technology, operator) either declared by the model or added freely. They are available downstream for filtering, aggregation and visualisation.
+
+    `Data`
+
+    [:octicons-arrow-right-24: Component properties](../user-guide/file-structure/system.md#properties)
+
+-   :material-swap-horizontal:{ .lg .middle } **Solver-agnostic by design**
+
+    ---
+
+    Model equations live in YAML files, never in software code, and are interpreted at run time. The optimisation solver is a configuration choice with solver-specific options passed through.
+
+    `Solving`
+
+    [:octicons-arrow-right-24: Solver configuration](../user-guide/file-structure/solver-optimization.md)
+
+
+
+
 
 -   :material-table-large:{ .lg .middle } **Full, granular results**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,7 @@ nav:
   - Home:
       - Home: index.md
       - Key Principles: home/key-principles.md
-      - Use Cases: home/use-cases.md
+      - Features and Use Cases: home/use-cases.md
       - Users of GEMS: home/users.md
       - Roadmap: home/roadmap.md
       - Release Notes: home/release-notes.md


### PR DESCRIPTION
## Process ID

**Process:** DOC-02

## Description

Extends the *Use Cases* page into **Features and Use Cases**, adding a grid of 13 tiles describing what the GEMS language and format support **today**, placed above the existing use-case list.

This addresses @tbittar's review comment on #221:

> I think what is missing are tiles for already supported features (investment, rolling horizon, and so on). It should probably not be in the roadmap, but I have not find it either on the overview page or the home page

The tiles are written at the same abstraction level as the roadmap tiles, reuse the roadmap's card style and tag convention (extended with `Solving` and `Data`), and each links to its reference page.

**Base branch:** this PR targets `documentation/roadmap` rather than `main`, because the new page cross-links to `home/roadmap.md` and sits next to it in the nav. It is a draft, intended to be merged after (or together with) #221.

The 13 tiles:

| Tile | Tag |
|---|---|
| Systems as graphs of connected components | `Language` |
| Readable, math-like expression syntax | `Language` |
| Multi-energy and sector coupling | `Language` |
| Time built into the language | `Language` |
| Uncertainty as a native dimension | `Language` |
| Scenario building from data series | `Data` |
| Component properties and metadata | `Data` |
| Solver-agnostic by design | `Solving` |
| LP, MIP and MILP problems | `Solving` |
| Investment and two-stage stochastic optimisation | `Solving` |
| Block decomposition of the horizon | `Solving` |
| Full, granular results | `Outputs` |
| Inspect the problem you actually solve | `Outputs` |

## Impact Analysis

- `doc/home/use-cases.md` — new title, new intro, new `## Features` section; the five existing use-case bullets are kept verbatim under `## Use Cases`.
- `mkdocs.yml` — nav label `Use Cases` → `Features and Use Cases`, same position.

No libraries, models or studies are affected. No breaking changes to existing studies.

Notes for reviewers:

- **The filename is deliberately unchanged.** Renaming it to match the new title would 404 the published URL `…/home/use-cases/` and any external link to it. Happy to rename if that trade-off is acceptable.
- **The "Block decomposition of the horizon" tile is the weakest of the 13.** Rolling horizon is named in the review comment, but the only documentation for it is the `block` column on the Simulation Table page — `optim-config.yml` is mentioned in `overview/file-structure.md` and has no user-guide page. The tile is therefore worded cautiously and links there. A dedicated page for `optim-config.yml` would let it say something more useful.
- **Two candidates were deliberately excluded**: Business Views (already a roadmap item under *Now*, and the docs flag it as under active development) and the taxonomy file format (also flagged as under development) — only the documented `properties` mechanism is covered.

## Checklist

- [x] E2E tests pass (or confirmed not affected) — documentation only
- [ ] Library version bumped if library changed (`library.version` in `libraries/<library>.yml`) — n/a
- [ ] Changelog entry added if library changed (`libraries/CHANGELOG-<library>.md`) — n/a
- [ ] Release notes entry added if language-level change (`doc/0_Home/4_release_notes.md`) — n/a, no language-level change
- [ ] Compatibility matrix updated if applicable (`COMPATIBILITY.md`) — n/a
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed — no impact